### PR TITLE
Facebook treats adoptions the same as births

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -163,7 +163,7 @@
     Company: Facebook
     Maternity: 16
     Paternity: 16
-    Adoption:
+    Adoption: 16
     Notes: $4000 cash bonus
     Source: kim@disqus.com
     policy_creation_date:


### PR DESCRIPTION
FB gives the same amount of leave for adoption or birth, regardless of gender.
