### PR TITLE
Fix yaml syntax

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -414,7 +414,7 @@
     Maternity: 20
     Paternity: 20
     Adoption:
-    Notes: For US employees: 20 weeks at full pay, starting two weeks before due date, 24 weeks if there are complications during birth.
+    Notes: "For US employees: 20 weeks at full pay, starting two weeks before due date, 24 weeks if there are complications during birth."
     Source: http://blog.travis-ci.com/2015-08-11-our-maternity-and-paternity-leave-for-us-employees/
     policy_creation_date: 2015-05-07
     policy_last_updated: 2015-08-07


### PR DESCRIPTION
Ruby's YAML parser fails on the line changed. The error is:

`...lib/ruby/2.2.0/psych.rb:370:in`parse': (<unknown>): mapping values are not allowed in this context at line 417 column 28 (Psych::SyntaxError)`

After this change, this error no longer occurs.
